### PR TITLE
feat: add one-click log and crashlog export (#57)

### DIFF
--- a/src/Flarial.Launcher/Controls/FolderButtonsBox.cs
+++ b/src/Flarial.Launcher/Controls/FolderButtonsBox.cs
@@ -1,4 +1,9 @@
+using System;
 using System.IO;
+using System.Threading.Tasks;
+using Flarial.Launcher.Interface;
+using Flarial.Launcher.Interface.Dialogs;
+using Flarial.Launcher.Utilities;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using static Windows.Win32.Foundation.HWND;
@@ -23,6 +28,13 @@ sealed class FolderButtonsBox : Grid
         HorizontalAlignment = HorizontalAlignment.Stretch
     };
 
+    readonly Button _exportLogsButton = new()
+    {
+        Content = "Export Logs",
+        VerticalAlignment = VerticalAlignment.Stretch,
+        HorizontalAlignment = HorizontalAlignment.Stretch
+    };
+
     unsafe static void OnButtonClick(object sender, RoutedEventArgs args)
     {
         var button = (Button)sender;
@@ -34,6 +46,21 @@ sealed class FolderButtonsBox : Grid
             ShellExecute(Null, null, lpFile, null, null, SW_NORMAL);
     }
 
+    async void OnExportLogsClick(object sender, RoutedEventArgs args)
+    {
+        try
+        {
+            var exportPath = LogExporter.Export(Path.GetTempPath());
+            fixed (char* lpFile = exportPath)
+                ShellExecute(Null, null, lpFile, null, null, SW_NORMAL);
+            await new LogExportSuccessDialog(exportPath).ShowAsync();
+        }
+        catch (Exception ex)
+        {
+            await new LogExportFailureDialog(ex.Message).ShowAsync();
+        }
+    }
+
     internal FolderButtonsBox()
     {
         _launcherFolderButton.Tag = ".";
@@ -41,8 +68,10 @@ sealed class FolderButtonsBox : Grid
 
         _clientFolderButton.Click += OnButtonClick;
         _launcherFolderButton.Click += OnButtonClick;
+        _exportLogsButton.Click += OnExportLogsClick;
 
         ColumnSpacing = 12;
+        ColumnDefinitions.Add(new());
         ColumnDefinitions.Add(new());
         ColumnDefinitions.Add(new());
 
@@ -52,7 +81,11 @@ sealed class FolderButtonsBox : Grid
         SetRow(_launcherFolderButton, 0);
         SetColumn(_launcherFolderButton, 1);
 
+        SetRow(_exportLogsButton, 0);
+        SetColumn(_exportLogsButton, 2);
+
         Children.Add(_clientFolderButton);
         Children.Add(_launcherFolderButton);
+        Children.Add(_exportLogsButton);
     }
 }

--- a/src/Flarial.Launcher/Interface/Dialogs/LogExportFailureDialog.cs
+++ b/src/Flarial.Launcher/Interface/Dialogs/LogExportFailureDialog.cs
@@ -1,0 +1,12 @@
+namespace Flarial.Launcher.Interface.Dialogs;
+
+sealed class LogExportFailureDialog : MasterDialog
+{
+    readonly string _reason;
+
+    internal LogExportFailureDialog(string reason) => _reason = reason;
+
+    protected override string Title => "Export Failed";
+    protected override string PrimaryButtonText => "OK";
+    protected override string Content => $"Failed to export logs:\n\n{_reason}";
+}

--- a/src/Flarial.Launcher/Interface/Dialogs/LogExportSuccessDialog.cs
+++ b/src/Flarial.Launcher/Interface/Dialogs/LogExportSuccessDialog.cs
@@ -1,0 +1,12 @@
+namespace Flarial.Launcher.Interface.Dialogs;
+
+sealed class LogExportSuccessDialog : MasterDialog
+{
+    readonly string _path;
+
+    internal LogExportSuccessDialog(string path) => _path = path;
+
+    protected override string Title => "Logs Exported";
+    protected override string PrimaryButtonText => "OK";
+    protected override string Content => $"Logs and crash files have been exported to:\n\n{_path}";
+}

--- a/src/Flarial.Launcher/Utilities/LogExporter.cs
+++ b/src/Flarial.Launcher/Utilities/LogExporter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Linq;
+using Flarial.Runtime.Game;
+
+namespace Flarial.Launcher.Utilities;
+
+static class LogExporter
+{
+    static readonly string[] s_logPatterns = ["*.txt", "*.log"];
+    static readonly string[] s_crashPatterns = ["*.dmp", "*.crash"];
+
+    static readonly string[] s_knownLogDirs = [
+        "logs",
+        "LocalState/logs",
+        "LocalState/games/com.mojang/logs"
+    ];
+
+    static readonly string[] s_knownCrashDirs = [
+        "crashes",
+        "LocalState/crashes",
+        "LocalState/games/com.mojang/crashes"
+    ];
+
+    internal static string Export(string destinationBase)
+    {
+        if (!Minecraft.IsInstalled)
+            throw new InvalidOperationException("Minecraft is not installed.");
+
+        var packagePath = Minecraft.Package.InstalledPath;
+        var exportPath = Path.Combine(destinationBase, $"FlarialLogs_{DateTime.Now:yyyyMMdd_HHmmss}");
+
+        Directory.CreateDirectory(exportPath);
+        var logsPath = Path.Combine(exportPath, "logs");
+        var crashesPath = Path.Combine(exportPath, "crashes");
+
+        var collected = 0;
+
+        foreach (var dir in s_knownLogDirs)
+        {
+            var fullPath = Path.Combine(packagePath, dir);
+            if (!Directory.Exists(fullPath)) continue;
+            collected += CopyFiles(fullPath, logsPath, s_logPatterns);
+        }
+
+        foreach (var dir in s_knownCrashDirs)
+        {
+            var fullPath = Path.Combine(packagePath, dir);
+            if (!Directory.Exists(fullPath)) continue;
+            collected += CopyFiles(fullPath, crashesPath, s_crashPatterns);
+        }
+
+        if (collected == 0)
+        {
+            Directory.Delete(exportPath, true);
+            throw new InvalidOperationException("No log or crash files found.");
+        }
+
+        return exportPath;
+    }
+
+    static int CopyFiles(string sourceDir, string destDir, string[] patterns)
+    {
+        int count = 0;
+
+        try
+        {
+            var files = patterns
+                .SelectMany(pattern => Directory.GetFiles(sourceDir, pattern, SearchOption.TopDirectoryOnly))
+                .Distinct();
+
+            Directory.CreateDirectory(destDir);
+
+            foreach (var file in files)
+            {
+                var dest = Path.Combine(destDir, Path.GetFileName(file));
+                File.Copy(file, dest, true);
+                count++;
+            }
+        }
+        catch { }
+
+        return count;
+    }
+}


### PR DESCRIPTION
## Summary
- Add one-click "Export Logs" button in Settings page that collects all diagnostic logs and crash logs
- Gathers files from known Minecraft directories (`logs`, `LocalState/logs`, `LocalState/games/com.mojang/logs` and crash equivalents)
- Exports to a timestamped folder in `%TEMP%` and opens it automatically for easy sharing with support
- Handles missing files and permission errors with clear user feedback

## Related Issue
Closes #57

## Changes
- `src/Flarial.Launcher/Utilities/LogExporter.cs` - New utility to collect and export log files
- `src/Flarial.Launcher/Interface/Dialogs/LogExportSuccessDialog.cs` - Success feedback dialog
- `src/Flarial.Launcher/Interface/Dialogs/LogExportFailureDialog.cs` - Error feedback dialog
- `src/Flarial.Launcher/Controls/FolderButtonsBox.cs` - Added "Export Logs" button alongside folder shortcuts