### PR TITLE
feat: add DLL injection handshake mechanism (#31)

### DIFF
--- a/src/Flarial.Runtime/Modding/Injector.cs
+++ b/src/Flarial.Runtime/Modding/Injector.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Flarial.Runtime.Game;
 using Flarial.Runtime.Unmanaged;
@@ -15,6 +16,8 @@ namespace Flarial.Runtime.Modding;
 
 public unsafe static class Injector
 {
+    internal const string HandshakeToken = "Flarial.Handshake.2026";
+
     static readonly LPTHREAD_START_ROUTINE s_routine;
 
     static Injector()
@@ -48,6 +51,10 @@ public unsafe static class Injector
                 fixed (char* buffer = library._path) WriteProcessMemory(process, address, buffer, size, null);
 
                 thread = CreateRemoteThread(process, null, 0, s_routine, address, 0, null);
+
+                fixed (char* token = HandshakeToken)
+                    SetThreadDescription(thread, new(token));
+
                 WaitForSingleObject(thread, INFINITE);
 
                 return processId;


### PR DESCRIPTION
## Summary
- Add handshake verification so the client DLL can confirm injection originated from the Flarial launcher
- Uses `SetThreadDescription` to tag the injection thread with a known token (`Flarial.Handshake.2026`)
- Prevents unwanted behaviors when DLL is injected via third-party injectors
- The client DLL calls `GetThreadDescription` and compares against the expected token before initializing

## Related Issue
Closes #31

## Changes
- `src/Flarial.Runtime/Modding/Injector.cs` - Add `SetThreadDescription` call after `CreateRemoteThread` and expose `HandshakeToken` constant