### PR TITLE
feat: add native ARM64 support

### DIFF
--- a/src/Flarial.Analytics/Flarial.Analytics.csproj
+++ b/src/Flarial.Analytics/Flarial.Analytics.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64;arm64</Platforms>
     <TargetFramework>net48</TargetFramework>
 
     <Optimize>true</Optimize>

--- a/src/Flarial.Launcher/Flarial.Launcher.csproj
+++ b/src/Flarial.Launcher/Flarial.Launcher.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64;arm64</Platforms>
     <TargetFramework>net48</TargetFramework>
 
     <UseWPF>true</UseWPF>

--- a/src/Flarial.Runtime/Flarial.Runtime.csproj
+++ b/src/Flarial.Runtime/Flarial.Runtime.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64;arm64</Platforms>
     <TargetFramework>net48</TargetFramework>
 
     <Nullable>enable</Nullable>

--- a/src/Flarial.Unmanaged/Flarial.Unmanaged.csproj
+++ b/src/Flarial.Unmanaged/Flarial.Unmanaged.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64;arm64</Platforms>
     <TargetFramework>net48</TargetFramework>
 
     <Optimize>true</Optimize>


### PR DESCRIPTION
## Summary
- Add native ARM64 (Windows on ARM) support alongside existing x64
- Replace hardcoded `<PlatformTarget>x64</PlatformTarget>` with `<Platforms>x64;arm64</Platforms>` across all 4 projects
- No code changes required — existing code is architecture-neutral (uses PE32+ headers, standard Win32 API via CsWin32)

## Changes
- `src/Flarial.Launcher/Flarial.Launcher.csproj`
- `src/Flarial.Runtime/Flarial.Runtime.csproj`
- `src/Flarial.Analytics/Flarial.Analytics.csproj`
- `src/Flarial.Unmanaged/Flarial.Unmanaged.csproj`