### PR TITLE
feat(launcher): add AdSense side banner ads via WebView2

### DIFF
--- a/src/Flarial.Launcher/Controls/BannerAdsView.cs
+++ b/src/Flarial.Launcher/Controls/BannerAdsView.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.Wpf;
+
+namespace Flarial.Launcher.Controls;
+
+sealed class BannerAdsView : ContentControl
+{
+    const string AdsUrl = "https://ecoursefree.com/CalcCourse.html";
+
+    const string PreInjectScriptTemplate = """
+        (function () {{
+            var slotIndex = {0};
+            try {{
+                var s = document.createElement('style');
+                s.id = '__flarial_pre_style';
+                s.textContent = `
+                    html, body {{ background: #000 !important; color: transparent !important; margin: 0 !important; padding: 0 !important; overflow: hidden !important; height: 100% !important; width: 100% !important; }}
+                `;
+                (document.head || document.documentElement).appendChild(s);
+            }} catch (_) {{}}
+
+            document.addEventListener('DOMContentLoaded', function () {{
+                try {{
+                    var nodes = document.querySelectorAll('ins.adsbygoogle');
+                    nodes.forEach(function (ins, i) {{
+                        if (i === slotIndex) {{
+                            ins.setAttribute('data-ad-format', 'vertical');
+                            ins.setAttribute('data-full-width-responsive', 'false');
+                            ins.style.display = 'inline-block';
+                            ins.style.width = '160px';
+                            ins.style.height = '600px';
+                        }} else {{
+                            ins.setAttribute('data-adsbygoogle-status', 'done');
+                            ins.style.display = 'none';
+                        }}
+                    }});
+                }} catch (_) {{}}
+            }});
+        }})();
+        """;
+
+    const string PostInjectScriptTemplate = """
+        (function () {{
+            var slotIndex = {0};
+            var s = document.createElement('style');
+            s.textContent = `
+                body > *:not(.__flarial_ad) {{ display: none !important; }}
+                body .__flarial_ad {{ display: flex !important; align-items: center !important; justify-content: center !important; width: 100% !important; height: 100vh !important; padding: 0 !important; margin: 0 !important; background: #000 !important; position: fixed !important; inset: 0 !important; }}
+                body .__flarial_ad ins.adsbygoogle, body .__flarial_ad ins.adsbygoogle iframe {{ display: inline-block !important; width: 160px !important; height: 600px !important; max-width: 100% !important; max-height: 100% !important; }}
+            `;
+            document.head.appendChild(s);
+
+            var nodes = document.querySelectorAll('ins.adsbygoogle');
+            var ins = nodes[slotIndex] || nodes[0];
+            if (!ins) return;
+
+            var wrap = document.createElement('div');
+            wrap.className = '__flarial_ad';
+            wrap.appendChild(ins);
+            document.body.appendChild(wrap);
+        }})();
+        """;
+
+    readonly WebView2 _webView = new()
+    {
+        DefaultBackgroundColor = System.Drawing.Color.Black
+    };
+
+    readonly int _slotIndex;
+
+    internal BannerAdsView(int slotIndex)
+    {
+        _slotIndex = slotIndex;
+        Background = Brushes.Black;
+        Content = _webView;
+
+        _webView.CoreWebView2InitializationCompleted += OnCoreReady;
+        Loaded += OnLoaded;
+    }
+
+    async void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoaded;
+        try { await _webView.EnsureCoreWebView2Async(); }
+        catch { }
+    }
+
+    async void OnCoreReady(object sender, CoreWebView2InitializationCompletedEventArgs e)
+    {
+        if (!e.IsSuccess) return;
+
+        var core = _webView.CoreWebView2;
+        core.Settings.AreDevToolsEnabled = true;
+        core.Settings.AreDefaultContextMenusEnabled = true;
+        core.Settings.IsStatusBarEnabled = false;
+        core.Settings.IsZoomControlEnabled = false;
+
+        var pre = string.Format(CultureInfo.InvariantCulture, PreInjectScriptTemplate, _slotIndex);
+        try { await core.AddScriptToExecuteOnDocumentCreatedAsync(pre); }
+        catch { }
+
+        core.NavigationCompleted += OnNavigationCompleted;
+        core.Navigate(AdsUrl);
+    }
+
+    async void OnNavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
+    {
+        if (!e.IsSuccess) return;
+        var script = string.Format(CultureInfo.InvariantCulture, PostInjectScriptTemplate, _slotIndex);
+        try { await _webView.CoreWebView2.ExecuteScriptAsync(script); }
+        catch { }
+    }
+}

--- a/src/Flarial.Launcher/Flarial.Launcher.csproj
+++ b/src/Flarial.Launcher/Flarial.Launcher.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Costura.Fody" Version="6.1.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3967.48" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.19041.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Flarial.Launcher/Interface/HostWindow.cs
+++ b/src/Flarial.Launcher/Interface/HostWindow.cs
@@ -1,6 +1,9 @@
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Flarial.Launcher.Controls;
 using Flarial.Launcher.Management;
 using Flarial.Launcher.Xaml;
 using Windows.Win32.Foundation;
@@ -39,12 +42,34 @@ sealed class HostWindow : Window
         WindowStartupLocation = WindowStartupLocation.CenterScreen;
 
         Title = "Flarial Launcher";
-        Content = new XamlHost(~new XamlContent(settings))
+
+        const double sideWidth = 200;
+        const double centerWidth = 960;
+        const double height = 540;
+
+        Grid grid = new() { Background = Brushes.Black };
+        grid.ColumnDefinitions.Add(new() { Width = new(sideWidth) });
+        grid.ColumnDefinitions.Add(new() { Width = new(centerWidth) });
+        grid.ColumnDefinitions.Add(new() { Width = new(sideWidth) });
+
+        var leftAd = new BannerAdsView(0) { Width = sideWidth, Height = height };
+        Grid.SetColumn(leftAd, 0);
+        grid.Children.Add(leftAd);
+
+        var host = new XamlHost(~new XamlContent(settings))
         {
-            Width = 960,
-            Height = 540,
+            Width = centerWidth,
+            Height = height,
             Focusable = true
         };
+        Grid.SetColumn(host, 1);
+        grid.Children.Add(host);
+
+        var rightAd = new BannerAdsView(1) { Width = sideWidth, Height = height };
+        Grid.SetColumn(rightAd, 2);
+        grid.Children.Add(rightAd);
+
+        Content = grid;
     }
 
     static nint HwndSourceHook(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)

--- a/src/Flarial.Launcher/Pages/HomePage.cs
+++ b/src/Flarial.Launcher/Pages/HomePage.cs
@@ -89,7 +89,7 @@ sealed class HomePage : Grid
 
         Children.Add(new PromotionImagesBox
         {
-            VerticalAlignment = VerticalAlignment.Bottom,
+            VerticalAlignment = VerticalAlignment.Top,
             HorizontalAlignment = HorizontalAlignment.Center
         });
 


### PR DESCRIPTION
## Summary
- Two 200px vertical ad columns flank the existing 960px launcher UI; window is now 1360x540 with the center XamlHost unchanged
- Each column hosts a `Microsoft.Web.WebView2` that loads the AdSense proxy page (ecoursefree.com/CalcCourse.html), pre-tags one `ins.adsbygoogle` slot as vertical 160x600 before AdSense initializes, then strips the rest of the page post-nav
- Existing LiteByte `PromotionImagesBox` moved from the bottom of `HomePage` to the top so the play area sits cleanly between the side ads

## Files
- `src/Flarial.Launcher/Controls/BannerAdsView.cs` (new) — WebView2-backed ad column, takes a slot index (0 = left, 1 = right)
- `src/Flarial.Launcher/Interface/HostWindow.cs` — wraps content in a 3-column Grid (200 / 960 / 200)
- `src/Flarial.Launcher/Pages/HomePage.cs` — `PromotionImagesBox` repositioned to top
- `src/Flarial.Launcher/Flarial.Launcher.csproj` — adds `Microsoft.Web.WebView2` 1.0.3967.48

## Test plan
- [ ] Launcher window opens at 1360x540
- [ ] LiteByte banner sits at the top center
- [ ] Left and right columns each render a distinct AdSense vertical banner
- [ ] Play button still launches Minecraft as before
- [ ] WebView2 Runtime is present on target machines (ships with Edge / Win11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)